### PR TITLE
Impact Analysis for CMS2 (QICore 4 to QICore 6)

### DIFF
--- a/input/cql/PCSDepressionScreenAndFollowUpFHIR.cql
+++ b/input/cql/PCSDepressionScreenAndFollowUpFHIR.cql
@@ -31,6 +31,12 @@ parameter "Measurement Period" Interval<DateTime>
 
 context Patient
 
+/*
+  @QICore6Uplift: 
+    - Update ObservationNotDone to ObservationCancelled
+    - Update Condition to ConditionProblemsHealthConcerns
+*/
+
 define "Initial Population":
   "Patient Age 12 Years or Older at Start of Measurement Period"
     and exists ( "Qualifying Encounter During Measurement Period" )

--- a/input/cql/PCSDepressionScreenAndFollowUpFHIR.cql
+++ b/input/cql/PCSDepressionScreenAndFollowUpFHIR.cql
@@ -38,12 +38,6 @@ parameter "Measurement Period" Interval<DateTime>
 
 context Patient
 
-/*
-  @QICore6Uplift: 
-    - Update ObservationNotDone to ObservationCancelled
-    - Update Condition to ConditionProblemsHealthConcerns
-*/
-
 define "Initial Population":
   "Patient Age 12 Years or Older at Start of Measurement Period"
     and exists ( "Qualifying Encounter During Measurement Period" )
@@ -107,6 +101,10 @@ define "Follow Up Intervention for Positive Adult Depression Screening":
       )
   )
 
+/*
+  @QICore6Uplift: Update ObservationNotDone to ObservationCancelled
+*/
+
 define "Has Adolescent Depression Screening":
   exists ( [Observation: "Adolescent depression screening assessment"] AdolescentScreening
       with "Qualifying Encounter During Measurement Period" QualifyingEncounter
@@ -114,6 +112,10 @@ define "Has Adolescent Depression Screening":
           and AdolescentScreening.value is not null
           and AdolescentScreening.status = 'final'
   )
+
+/*
+  @QICore6Uplift: Update ObservationNotDone to ObservationCancelled
+*/
 
 define "Has Adult Depression Screening":
   exists ( [Observation: "Adult depression screening assessment"] AdultScreening
@@ -132,6 +134,10 @@ define "Has Most Recent Adult Screening Negative":
   ( "Most Recent Adult Depression Screening" AdultScreen
       where AdultScreen.value ~ "Depression screening negative (finding)"
   ) is not null
+
+/*
+  @QICore6Uplift: Update Condition to ConditionProblemsHealthConcerns
+*/
 
 define "History of Bipolar Diagnosis Before Qualifying Encounter":
   [Condition: "Bipolar Disorder"] BipolarDiagnosis

--- a/input/cql/PCSDepressionScreenAndFollowUpFHIR.cql
+++ b/input/cql/PCSDepressionScreenAndFollowUpFHIR.cql
@@ -101,10 +101,6 @@ define "Follow Up Intervention for Positive Adult Depression Screening":
       )
   )
 
-/*
-  @QICore6Uplift: Update ObservationNotDone to ObservationCancelled
-*/
-
 define "Has Adolescent Depression Screening":
   exists ( [Observation: "Adolescent depression screening assessment"] AdolescentScreening
       with "Qualifying Encounter During Measurement Period" QualifyingEncounter
@@ -112,10 +108,6 @@ define "Has Adolescent Depression Screening":
           and AdolescentScreening.value is not null
           and AdolescentScreening.status = 'final'
   )
-
-/*
-  @QICore6Uplift: Update ObservationNotDone to ObservationCancelled
-*/
 
 define "Has Adult Depression Screening":
   exists ( [Observation: "Adult depression screening assessment"] AdultScreening
@@ -147,6 +139,10 @@ define "History of Bipolar Diagnosis Before Qualifying Encounter":
       )
         and BipolarDiagnosis.prevalenceInterval ( ) starts before QualifyingEncounter.period
 
+/*
+  @QICore6Uplift: Update ObservationNotDone to ObservationCancelled
+*/
+
 define "Medical or Patient Reason for Not Screening Adolescent for Depression":
   [ObservationNotDone: code ~ "Adolescent depression screening assessment"] NoAdolescentScreen
     with "Qualifying Encounter During Measurement Period" QualifyingEncounter
@@ -155,6 +151,10 @@ define "Medical or Patient Reason for Not Screening Adolescent for Depression":
         or NoAdolescentScreen.notDoneReason in "Medical Reason"
     )
       and NoAdolescentScreen.status = 'cancelled'
+
+/*
+  @QICore6Uplift: Update ObservationNotDone to ObservationCancelled
+*/
 
 define "Medical or Patient Reason for Not Screening Adult for Depression":
   [ObservationNotDone: code ~ "Adult depression screening assessment"] NoAdultScreen

--- a/input/cql/PCSDepressionScreenAndFollowUpFHIR.cql
+++ b/input/cql/PCSDepressionScreenAndFollowUpFHIR.cql
@@ -201,9 +201,9 @@ define "Patient Age 18 Years or Older at Start of Measurement Period":
   AgeInYearsAt(date from start of "Measurement Period") >= 18
 
 define "Qualifying Encounter During Measurement Period":
-  ( [Encounter: "Encounter to Screen for Depression"]
-    union [Encounter: "Physical Therapy Evaluation"]
-    union [Encounter: "Telephone Visits"] ) QualifyingEncounter
+  ( [Encounter: type in "Encounter to Screen for Depression"]
+    union [Encounter: type in "Physical Therapy Evaluation"]
+    union [Encounter: type in "Telephone Visits"] ) QualifyingEncounter
     where QualifyingEncounter.period during day of "Measurement Period"
       and QualifyingEncounter.status = 'finished'
 

--- a/input/cql/PCSDepressionScreenAndFollowUpFHIR.cql
+++ b/input/cql/PCSDepressionScreenAndFollowUpFHIR.cql
@@ -1,3 +1,10 @@
+/*
+  Test impact for QICore6 uplift: 
+    - HL7 FHIR profile urls should be changed to the following: 
+      "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"
+			"http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"
+*/
+
 library PCSDepressionScreenAndFollowUpFHIR version '0.2.000'
 
 using QICore version '4.1.1'


### PR DESCRIPTION
I added impact analysis for QICore6 uplift for CMS2. Specifically, I added notes to update the following: 
- ObservationNotDone resource to ObservationCancelled resource
- Condition to ConditionProblemsHealthConcerns

Also, added 'type in' keywords to Encounter types

Data Requirements and Mapping to USCDI+ Elements: [Impact Analysis CMS2 (QICore v4.1.1 to v6.0.0).xlsx](https://github.com/user-attachments/files/17085524/Impact.Analysis.CMS2.QICore.v4.1.1.to.v6.0.0.xlsx)